### PR TITLE
Adds tunable for `--work-dir` flag 

### DIFF
--- a/concourse-worker/default.toml
+++ b/concourse-worker/default.toml
@@ -1,2 +1,4 @@
 [ports]
 web = "8080"
+
+work_dir = "/opt/concourse/worker"

--- a/concourse-worker/hooks/init
+++ b/concourse-worker/hooks/init
@@ -2,4 +2,4 @@
 #
 exec 2>&1
 
-mkdir -p /opt/concourse/worker
+mkdir -p {{cfg.work_dir}}

--- a/concourse-worker/hooks/run
+++ b/concourse-worker/hooks/run
@@ -7,7 +7,7 @@ source "{{pkg.svc_config_path}}/config.sh"
 cd {{pkg.svc_path}}
 
 concourse worker \
- --work-dir {{pkg.svc_var_path}} \
+ --work-dir {{cfg.work_dir}} \
  {{~#if bind.web ~}}
  {{#with bind.web.first as |web| }}
  --tsa-host {{web.sys.ip}} \


### PR DESCRIPTION
This is the same bug I saw when testing concourse locally. Getting appropriate permissions for runc containers to run under `{{pkg.svc_var_path}}` will be what we want to figure out. For now this patch redirects the location that containers spawn to `/opt/concourse/worker` which is the default location for the containers.

Signed-off-by: Ian Henry <ihenry@chef.io>