### PR TITLE
Corrects default.toml

### DIFF
--- a/concourse-worker/default.toml
+++ b/concourse-worker/default.toml
@@ -1,4 +1,4 @@
+work_dir = "/opt/concourse/worker"
+
 [ports]
 web = "8080"
-
-work_dir = "/opt/concourse/worker"


### PR DESCRIPTION
Apparently, if the first entry in toml is an array marker e.g. `[ports]` then the remaining line after a line break does not get read or rendered. This corrects the issue by moving the entry to the top of the file.

Signed-off-by: Ian Henry <ihenry@chef.io>