### PR TITLE
Correct optional binding to match the export of concourse-web

### DIFF
--- a/concourse-worker/plan.sh
+++ b/concourse-worker/plan.sh
@@ -9,7 +9,7 @@ pkg_svc_group="root"
 pkg_svc_user="root"
 pkg_deps=(core/concourse core/iptables core/bash core/findutils)
 pkg_binds_optional=(
-   [web]="host"
+   [web]="web_port"
 )
 
 do_build(){


### PR DESCRIPTION
The previous binding setting corresponds to something not actually exported by the concourse-web application. Given that the binding is only used to find the IP of the web server, this PR changes the binding to match the web_port field exported by concourse-web.

Signed-off-by: Jon Cowie <jonlives@gmail.com>