### PR TITLE
Update binding for stricter sup

### DIFF
--- a/concourse-web/plan.sh
+++ b/concourse-web/plan.sh
@@ -13,7 +13,7 @@ pkg_exports=(
 )
 pkg_exposes=(web_port)
 pkg_binds_optional=(
-   [database]="web_port host"
+   [database]="port"
 )
 
 do_build(){


### PR DESCRIPTION
We need to look for a binding that exists now under 0.57.0 of hab. This is the same issue as https://github.com/habitat-sh/plan-ci/pull/11